### PR TITLE
Remove info about plugin in DesktopEditors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Convert selected text into speech.
 
 The plugin uses Yandex.Translate to recognize the language and the [ResponsiveVoice service](https://responsivevoice.org/) to read the text out loud. By default, it uses a female voice. 
 
-The Speech plugin is installed by default in cloud, [self-hosted](https://github.com/ONLYOFFICE/DocumentServer) and [desktop version](https://github.com/ONLYOFFICE/DesktopEditors) of ONLYOFFICE editors. 
+The Speech plugin is installed by default in cloud and [self-hosted](https://github.com/ONLYOFFICE/DocumentServer) of ONLYOFFICE editors. 
 
 ## How to use
 


### PR DESCRIPTION
Plugin may be included in older version, but currently in v6.0.0 and later is not

See:
https://github.com/ONLYOFFICE/build_tools/blob/a1f19d41dcc63a5c0c97a9deb0e5e6a1ce107641/defaults#L1